### PR TITLE
Use similar method names for export and import apis

### DIFF
--- a/sdk/personalizer/Azure.AI.Personalizer/src/Models/PersonalizerAdministrationClient.cs
+++ b/sdk/personalizer/Azure.AI.Personalizer/src/Models/PersonalizerAdministrationClient.cs
@@ -306,10 +306,24 @@ namespace Azure.AI.Personalizer
             }
         }
 
+        /// <summary> Export the current model used by Personalizer service. </summary>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
+        /// <remarks> Gets the signed Personalizer model. </remarks>
+        public virtual async Task<Response<Stream>> ExportPersonalizerSignedModelAsync(CancellationToken cancellationToken = default)
+        {
+            return await GetPersonalizerModelAsync(true, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary> Export the current model used by Personalizer service. </summary>
+        public virtual Response<Stream> ExportPersonalizerSignedModel(CancellationToken cancellationToken = default)
+        {
+            return GetPersonalizerModel(isSigned: true, cancellationToken);
+        }
+
         /// <summary> Replace the current model used by Personalizer service with an updated model. </summary>
         /// <param name="modelStream">Stream representing the digitally signed model zip archive.</param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<Response> ImportPersonalizerModelAsync(Stream modelStream, CancellationToken cancellationToken = default)
+        public virtual async Task<Response> ImportPersonalizerSignedModelAsync(Stream modelStream, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("PersonalizerAdministrationClient.ImportPersonalizerModel");
             scope.Start();
@@ -327,7 +341,7 @@ namespace Azure.AI.Personalizer
         /// <summary> Replace the current model used by Personalizer service with an updated model. </summary>
         /// <param name="modelStream">Stream representing the digitally signed model zip archive.</param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual Response ImportPersonalizerModel(Stream modelStream, CancellationToken cancellationToken = default)
+        public virtual Response ImportPersonalizerSignedModel(Stream modelStream, CancellationToken cancellationToken = default)
         {
             using var scope = _clientDiagnostics.CreateScope("PersonalizerAdministrationClient.ImportPersonalizerModel");
             scope.Start();

--- a/sdk/personalizer/Azure.AI.Personalizer/tests/Personalizer/ModelTests.cs
+++ b/sdk/personalizer/Azure.AI.Personalizer/tests/Personalizer/ModelTests.cs
@@ -18,10 +18,19 @@ namespace Azure.AI.Personalizer.Tests
         {
             PersonalizerAdministrationClient client = GetAdministrationClient(isSingleSlot: true);
             await GetModel(false, client);
+            await GetModel(true, client);
             await GetModelProperties(client);
-            Response<Stream> response = await GetModel(true, client);
-            await ImportModel(response.Value, client);
+            Response<Stream> response = await ExportSignedModel(client);
+            await ImportSignedModel(response.Value, client);
             await ResetModel(client);
+        }
+
+        [Test]
+        public async Task ExportImportModelTest()
+        {
+            PersonalizerAdministrationClient client = GetAdministrationClient(isSingleSlot: true);
+            Response<Stream> response = await ExportSignedModel(client);
+            await ImportSignedModel(response.Value, client);
         }
 
         private async Task<Response<Stream>> GetModel(bool signed, PersonalizerAdministrationClient client)
@@ -29,9 +38,14 @@ namespace Azure.AI.Personalizer.Tests
             return await client.GetPersonalizerModelAsync(signed);
         }
 
-        private async Task<Response> ImportModel(Stream modelStream, PersonalizerAdministrationClient client)
+        private async Task<Response<Stream>> ExportSignedModel(PersonalizerAdministrationClient client)
         {
-            return await client.ImportPersonalizerModelAsync(modelStream);
+            return await client.ExportPersonalizerSignedModelAsync();
+        }
+
+        private async Task<Response> ImportSignedModel(Stream modelStream, PersonalizerAdministrationClient client)
+        {
+            return await client.ImportPersonalizerSignedModelAsync(modelStream);
         }
 
         private async Task ResetModel(PersonalizerAdministrationClient client)


### PR DESCRIPTION
Use similar naming convention for export and import model apis for ease of understanding.